### PR TITLE
Update the index to be group specific for Mark Task Command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteTaskFromGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTaskFromGroupCommand.java
@@ -50,18 +50,13 @@ public class DeleteTaskFromGroupCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        List<Task> lastShownList = model.getFilteredTaskList();
+        Group group = model.getGroupByName(toDeleteFrom);
+        List<Task> lastShownList = group.getTasks().stream().toList();
 
-        // the index here refers to the index in the list of all tasks from all groups
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
         }
         Task task = lastShownList.get(index.getZeroBased());
-        Group group = model.getGroupByName(toDeleteFrom);
-
-        if (!model.hasTaskInGroup(task, group)) {
-            throw new CommandException(MESSAGE_TASK_NOT_IN_GROUP);
-        }
 
         model.deleteTaskFromGroup(task, group);
         model.deleteTask(task);

--- a/src/main/java/seedu/address/logic/commands/MarkTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkTaskCommand.java
@@ -11,6 +11,7 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.group.Group;
 import seedu.address.model.group.GroupName;
 import seedu.address.model.task.Status;
 import seedu.address.model.task.Task;
@@ -54,9 +55,9 @@ public class MarkTaskCommand extends Command {
             throw new CommandException(GROUP_NOT_FOUND);
         }
 
-        List<Task> lastShownList = model.getFilteredTaskList();
+        Group group = model.getGroupByName(toMarkFrom);
+        List<Task> lastShownList = group.getTasks().stream().toList();
 
-        // the index here refers to the index in the list of all tasks from all groups
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }

--- a/src/main/java/seedu/address/logic/commands/MarkTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkTaskCommand.java
@@ -30,7 +30,7 @@ public class MarkTaskCommand extends Command {
             + PREFIX_GROUP_NAME + "Team 5 "
             + PREFIX_INDEX + "2";
 
-    public static final String MESSAGE_SUCCESS = "Changed the status of task: %1$s";
+    public static final String MESSAGE_SUCCESS = "Changed the status of task: %1$s to %2$s";
     public static final String GROUP_NOT_FOUND = "Group not found";
 
     private final Index index;
@@ -63,10 +63,10 @@ public class MarkTaskCommand extends Command {
         }
         Task taskToMark = lastShownList.get(index.getZeroBased());
         Status changedStatus = taskToMark.getStatus().equals(Status.PENDING) ? Status.COMPLETED : Status.PENDING;
-        Task markedTask = new Task(taskToMark.getTaskName(), taskToMark.getDeadline(), changedStatus);
+        Task editedTask = new Task(taskToMark.getTaskName(), taskToMark.getDeadline(), changedStatus);
 
-        model.setTask(taskToMark, markedTask);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(markedTask)));
+        model.setTask(taskToMark, editedTask, group);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(taskToMark), changedStatus));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -141,7 +141,10 @@ public class AddressBook implements ReadOnlyAddressBook {
      * {@code student} and {@code group} must exist in the address book.
      */
     public void addStudentToGroup(Student student, Group group) {
+        requireNonNull(student);
+        requireNonNull(group);
         group.add(student);
+        students.setPerson(student, student.addGroup(group.getGroupName()));
     }
 
     /**

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -250,10 +250,12 @@ public class AddressBook implements ReadOnlyAddressBook {
         group.deleteTask(task);
     }
 
-    public void setTask(Task target, Task editedTask) {
+    public void setTask(Task target, Task editedTask, Group group) {
+        requireNonNull(target);
         requireNonNull(editedTask);
-
+        requireNonNull(group);
         tasks.setTask(target, editedTask);
+        group.setTask(target, editedTask);
     }
 
     //// util methods

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -96,10 +96,10 @@ public interface Model {
     void setPerson(Student target, Student editedStudent);
 
     /**
-     * Replaces the given task {@code target} with {@code editedTask}.
+     * Replaces the given task {@code target} with {@code editedTask} in {@code group}.
      * {@code target} must exist in the address book.
      */
-    void setTask(Task target, Task editedTask);
+    void setTask(Task target, Task editedTask, Group group);
 
     /**
      * Returns true if a group with the same identity as {@code group} exists in the address book.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -175,9 +175,9 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void setTask(Task target, Task editedTask) {
-        requireAllNonNull(target, editedTask);
-        addressBook.setTask(target, editedTask);
+    public void setTask(Task target, Task editedTask, Group group) {
+        requireAllNonNull(target, editedTask, group);
+        addressBook.setTask(target, editedTask, group);
         updateFilteredTaskList(PREDICATE_SHOW_ALL_TASKS);
     }
 

--- a/src/main/java/seedu/address/model/group/Group.java
+++ b/src/main/java/seedu/address/model/group/Group.java
@@ -86,6 +86,11 @@ public class Group {
         tasks.remove(task);
     }
 
+    public void setTask(Task target, Task editedTask) {
+        deleteTask(target);
+        addTask(editedTask);
+    }
+
     public void delete(Student student) {
         students.remove(student);
     }

--- a/src/main/java/seedu/address/model/student/Student.java
+++ b/src/main/java/seedu/address/model/student/Student.java
@@ -91,10 +91,17 @@ public class Student {
     }
 
     /**
-     * Returns a copy of student which has no group
+     * Returns a copy of student which has no group.
      */
     public Student removeGroup() {
         return new Student(name, email, tags, studentNumber, Optional.empty());
+    }
+
+    /**
+     * Returns a copy of student which has {@code groupName}.
+     */
+    public Student addGroup(GroupName groupName) {
+        return new Student(name, email, tags, studentNumber, Optional.of(groupName));
     }
 
     /**

--- a/src/main/java/seedu/address/model/task/UniqueTaskList.java
+++ b/src/main/java/seedu/address/model/task/UniqueTaskList.java
@@ -10,6 +10,8 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.student.exceptions.DuplicatePersonException;
 import seedu.address.model.student.exceptions.PersonNotFoundException;
+import seedu.address.model.task.exceptions.DuplicateTaskException;
+import seedu.address.model.task.exceptions.TaskNotFoundException;
 
 /**
  * A list of persons that enforces uniqueness between its elements and does not allow nulls.
@@ -58,11 +60,11 @@ public class UniqueTaskList implements Iterable<Task> {
 
         int index = internalList.indexOf(target);
         if (index == -1) {
-            throw new PersonNotFoundException();
+            throw new TaskNotFoundException();
         }
 
         if (!target.isSameTask(editedTask) && contains(editedTask)) {
-            throw new DuplicatePersonException();
+            throw new DuplicateTaskException();
         }
 
         internalList.set(index, editedTask);

--- a/src/main/java/seedu/address/model/task/exceptions/DuplicateTaskException.java
+++ b/src/main/java/seedu/address/model/task/exceptions/DuplicateTaskException.java
@@ -1,0 +1,8 @@
+package seedu.address.model.task.exceptions;
+
+/**
+ * Signals that the operation will result in duplicate Tasks (Tasks are considered duplicates if they have the same
+ * identity).
+ */
+public class DuplicateTaskException extends RuntimeException {
+}

--- a/src/main/java/seedu/address/model/task/exceptions/TaskNotFoundException.java
+++ b/src/main/java/seedu/address/model/task/exceptions/TaskNotFoundException.java
@@ -1,0 +1,9 @@
+package seedu.address.model.task.exceptions;
+
+/**
+ * Signals that the operation is unable to find the specified task.
+ */
+public class TaskNotFoundException extends RuntimeException {
+    public TaskNotFoundException() {
+    }
+}

--- a/src/test/data/JsonSerializableAddressBookTest/duplicateGroupAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicateGroupAddressBook.json
@@ -1,10 +1,13 @@
 {
   "persons": [ ],
+  "tasks" : [ ],
   "groups" : [ {
     "students" : [ ],
-    "groupName" : "Team4"
+    "groupName" : "Team4",
+    "tasks" : [ ]
   }, {
     "students" : [ ],
-    "groupName" : "Team4"
+    "groupName" : "Team4",
+    "tasks" : [ ]
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -3,12 +3,14 @@
     "name": "Alice Pauline",
     "email": "alice@u.nus.edu",
     "tags": [ "friends" ],
-    "student number" : "A0111111J"
+    "student number" : "A0111111J",
+    "group": "Team 1"
   }, {
     "name": "Alice Pauline",
     "email": "pauline@u.nus.edu",
     "student number" : "A0111111J",
-    "email": "pauline@u.nus.edu"
+    "group": "Team 1"
   } ],
-  "groups" : [ ]
+  "groups" : [ ],
+  "tasks" : [ ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/invalidGroupAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidGroupAddressBook.json
@@ -1,7 +1,9 @@
 {
   "persons": [ ],
+  "tasks": [ ],
   "groups" : [ {
     "students" : [ ],
-    "groupName" : ",,,,,,"
+    "groupName" : ",,,,,,",
+    "tasks" : [ ]
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
@@ -1,7 +1,10 @@
 {
   "persons": [ {
     "name": "Hans Muster",
-    "email": "invalid@email!3e"
+    "email": "invalid@email!3e",
+    "student number": "A0123456Z",
+    "group": "Team 1"
   } ],
-  "groups" : [ ]
+  "groups" : [ ],
+  "tasks" : [ ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalGroupAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalGroupAddressBook.json
@@ -1,5 +1,6 @@
 {
   "persons" : [ ],
+  "tasks" : [ ],
   "groups" : [ {
     "students" : [ ],
     "groupName" : "Team5"

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -4,37 +4,45 @@
     "name" : "Alice Pauline",
     "email" : "alice@u.nus.edu",
     "tags" : [ "friends" ],
-    "student number" : "A0111111J"
+    "student number" : "A0111111J",
+    "group" : "Team 1"
   }, {
     "name" : "Benson Meier",
     "email" : "johnd@u.nus.edu",
     "tags" : [ "owesMoney", "friends" ],
-    "student number" : "A0222222H"
+    "student number" : "A0222222H",
+    "group" : "Team 2"
   }, {
     "name" : "Carl Kurz",
     "email" : "heinz@u.nus.edu",
     "tags" : [ ],
-    "student number" : "A0333333M"
+    "student number" : "A0333333M",
+    "group" : "Team 3"
   }, {
     "name" : "Daniel Meier",
     "email" : "cornelia@u.nus.edu",
     "tags" : [ "friends" ],
-    "student number" : "A0444444N"
+    "student number" : "A0444444N",
+    "group" : "Team 2"
   }, {
     "name" : "Elle Meyer",
     "email" : "werner@u.nus.edu",
     "tags" : [ ],
-    "student number" : "A0555555H"
+    "student number" : "A0555555H",
+    "group" : "Team 1"
   }, {
     "name" : "Fiona Kunz",
     "email" : "lydia@u.nus.edu",
     "tags" : [ ],
-    "student number" : "A0666666J"
+    "student number" : "A0666666J",
+    "group" : "Team 2"
   }, {
     "name" : "George Best",
     "email" : "anna@u.nus.edu",
     "tags" : [ ],
-    "student number" : "A0888888M"
+    "student number" : "A0888888M",
+    "group" : "Team 1"
   } ],
-  "groups" : [ ]
+  "groups" : [ ],
+  "tasks" : [ ]
 }

--- a/src/test/java/seedu/address/logic/commands/AddGroupCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddGroupCommandTest.java
@@ -131,6 +131,21 @@ public class AddGroupCommandTest {
         }
 
         @Override
+        public String getMostRecentGroupTaskDisplay() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setMostRecentGroupTaskDisplay() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setMostRecentGroupTaskDisplay(String string) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public Path getAddressBookFilePath() {
             throw new AssertionError("This method should not be called.");
         }
@@ -167,6 +182,11 @@ public class AddGroupCommandTest {
 
         @Override
         public void setPerson(Student target, Student editedStudent) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setTask(Task target, Task editedTask, Group group) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/AddStudentCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddStudentCommandTest.java
@@ -126,6 +126,21 @@ public class AddStudentCommandTest {
         }
 
         @Override
+        public String getMostRecentGroupTaskDisplay() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setMostRecentGroupTaskDisplay() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setMostRecentGroupTaskDisplay(String string) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public Path getAddressBookFilePath() {
             throw new AssertionError("This method should not be called.");
         }
@@ -162,6 +177,11 @@ public class AddStudentCommandTest {
 
         @Override
         public void setPerson(Student target, Student editedStudent) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setTask(Task target, Task editedTask, Group group) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/DeleteStudentFromGroupCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteStudentFromGroupCommandTest.java
@@ -113,6 +113,21 @@ public class DeleteStudentFromGroupCommandTest {
         }
 
         @Override
+        public String getMostRecentGroupTaskDisplay() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setMostRecentGroupTaskDisplay() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setMostRecentGroupTaskDisplay(String string) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public Path getAddressBookFilePath() {
             throw new AssertionError("This method should not be called.");
         }
@@ -149,6 +164,11 @@ public class DeleteStudentFromGroupCommandTest {
 
         @Override
         public void setPerson(Student target, Student editedStudent) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setTask(Task target, Task editedTask, Group group) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/model/student/StudentTest.java
+++ b/src/test/java/seedu/address/model/student/StudentTest.java
@@ -43,14 +43,14 @@ public class StudentTest {
         editedAlice = new PersonBuilder(ALICE).withStudentNumber(VALID_STUDENT_NUMBER_BOB).build();
         assertFalse(ALICE.isSamePerson(editedAlice));
 
-        // name differs in case, all other attributes same -> returns false
+        // name differs in case, all other attributes same -> returns true
         Student editedBob = new PersonBuilder(BOB).withName(VALID_NAME_AMY.toLowerCase()).build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        assertTrue(BOB.isSamePerson(editedBob));
 
-        // student name has trailing spaces, all other attributes same -> returns false
+        // student name has trailing spaces, all other attributes same -> returns true
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
         editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        assertTrue(BOB.isSamePerson(editedBob));
     }
 
     @Test


### PR DESCRIPTION
and Delete Task from Group

In the MarkTask and DeleteTaskFromGroup commands, they have an index parameter that refers to the task to update. Previously, the execute method for both commands made the index refer to the position of the task in a list of all tasks globally instead of the position in a list of tasks for a specific group.

Since being group specific is more intuitive as there is also a parameter for a group name, the index now refers to the position of a task in a list of tasks for a specific group.