### PR TITLE
Fix AddressBook not saving student with updated GroupName attribute

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -143,7 +143,8 @@ public class AddressBook implements ReadOnlyAddressBook {
     public void addStudentToGroup(Student student, Group group) {
         requireNonNull(group);
         requireNonNull(student);
-        group.add(student);
+        // temp fix - to be removed when we change to store just student number
+        group.add(student.setStudentGroup(group.getGroupName()));
         students.setPerson(student, student.setStudentGroup(group.getGroupName()));
     }
 


### PR DESCRIPTION
occurs after adding student to a group

Student will have "!" as GroupName within the `group` in the JSON file, but the appropriate `group` name in student object in JSON file.

This fixes the issue mentioned above.