### PR TITLE
Enable text wrap for result display

### DIFF
--- a/src/main/java/seedu/address/ui/ResultDisplay.java
+++ b/src/main/java/seedu/address/ui/ResultDisplay.java
@@ -23,6 +23,7 @@ public class ResultDisplay extends UiPart<Region> {
     public void setFeedbackToUser(String feedbackToUser) {
         requireNonNull(feedbackToUser);
         resultDisplay.setText(feedbackToUser);
+        resultDisplay.setWrapText(true);
     }
 
 }

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -40,7 +40,7 @@
         </StackPane>
 
         <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
-                   minHeight="100" prefHeight="100" maxHeight="100">
+                   minHeight="130" prefHeight="100" maxHeight="130">
           <padding>
             <Insets top="5" right="10" bottom="5" left="10" />
           </padding>


### PR DESCRIPTION
Small enhancement since some command's message usage is currently too long and will overflow the result display leading to unpleasant UX.

Just a temporary fix, we can update again in v1.5