### PR TITLE
Fix list bugs

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -67,10 +67,10 @@ public class LogicManager implements Logic {
         Command command = addressBookParser.parseCommand(commandText);
         commandResult = command.execute(model);
         this.versionHistory = command.updateVersionHistory(versionHistory, model);
-        ReadOnlyAddressBook tempAddressBook = versionHistory.getVersions().get(versionHistory.getCurrentVersionIndex());
-        ReadOnlyAddressBook currentAddressBook = new AddressBook().duplicateCopy(tempAddressBook);
-        model.setAddressBook(currentAddressBook);
         try {
+            ReadOnlyAddressBook tempAddressBook = versionHistory.getVersions().get(versionHistory.getCurrentVersionIndex());
+            ReadOnlyAddressBook currentAddressBook = new AddressBook().duplicateCopy(tempAddressBook);
+            model.setAddressBook(currentAddressBook);
             storage.saveAddressBook(currentAddressBook);
             storage.saveUserPrefs(model.getUserPrefs());
             versionHistoryStorage.saveVersionHistory(versionHistory);
@@ -78,6 +78,8 @@ public class LogicManager implements Logic {
             throw new CommandException(String.format(FILE_OPS_PERMISSION_ERROR_FORMAT, e.getMessage()), e);
         } catch (IOException ioe) {
             throw new CommandException(String.format(FILE_OPS_ERROR_FORMAT, ioe.getMessage()), ioe);
+        } catch (IndexOutOfBoundsException iob) {
+            return commandResult;
         }
 
         return commandResult;

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -68,7 +68,8 @@ public class LogicManager implements Logic {
         commandResult = command.execute(model);
         this.versionHistory = command.updateVersionHistory(versionHistory, model);
         try {
-            ReadOnlyAddressBook tempAddressBook = versionHistory.getVersions().get(versionHistory.getCurrentVersionIndex());
+            ReadOnlyAddressBook tempAddressBook =
+                    versionHistory.getVersions().get(versionHistory.getCurrentVersionIndex());
             ReadOnlyAddressBook currentAddressBook = new AddressBook().duplicateCopy(tempAddressBook);
             model.setAddressBook(currentAddressBook);
             storage.saveAddressBook(currentAddressBook);


### PR DESCRIPTION
Fixed the bug where list commands don't work when versionhistory.json does not exist.

There's another bug though, where users are unable to undo the first addition made to the model. This is (possibly) because of how version history storage works. Versions of the model are saved to VersionHistory only when a command is made. The first ever version of the model (aka when it is booted up for the first time) will not be saved to the system, so users can't undo to that state. Could potentially be quite tricky to fix if not handled properly.