### PR TITLE
Update necessary equals methods to ignoreCase

### DIFF
--- a/src/main/java/seedu/address/model/group/GroupName.java
+++ b/src/main/java/seedu/address/model/group/GroupName.java
@@ -62,7 +62,7 @@ public class GroupName {
         }
 
         seedu.address.model.group.GroupName otherName = (seedu.address.model.group.GroupName) other;
-        return fullName.equals(otherName.fullName);
+        return fullName.equalsIgnoreCase(otherName.fullName);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/group/GroupName.java
+++ b/src/main/java/seedu/address/model/group/GroupName.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class GroupName {
 
     public static final String MESSAGE_CONSTRAINTS =
-        "Group Names should only contain alphanumeric characters and spaces, and it should not be blank.";
+        "Group Names should only contain alphanumeric characters, spaces and hyphens, and it should not be blank.";
 
     /*
      * The first character of the address must not be a whitespace,

--- a/src/main/java/seedu/address/model/student/Email.java
+++ b/src/main/java/seedu/address/model/student/Email.java
@@ -60,7 +60,7 @@ public class Email {
         }
 
         Email otherEmail = (Email) other;
-        return value.equals(otherEmail.value);
+        return value.equalsIgnoreCase(otherEmail.value);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/student/Name.java
+++ b/src/main/java/seedu/address/model/student/Name.java
@@ -56,7 +56,7 @@ public class Name {
         }
 
         Name otherName = (Name) other;
-        return fullName.equals(otherName.fullName);
+        return fullName.equalsIgnoreCase(otherName.fullName);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -48,7 +48,7 @@ public class Tag {
         }
 
         Tag otherTag = (Tag) other;
-        return tagName.equals(otherTag.tagName);
+        return tagName.equalsIgnoreCase(otherTag.tagName);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/task/TaskName.java
+++ b/src/main/java/seedu/address/model/task/TaskName.java
@@ -55,7 +55,7 @@ public class TaskName {
         if (!(other instanceof TaskName otherName)) {
             return false;
         }
-        return taskName.equals(otherName.taskName);
+        return taskName.equalsIgnoreCase(otherName.taskName);
     }
 
     @Override

--- a/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
@@ -46,11 +46,11 @@ public class JsonAddressBookStorage implements AddressBookStorage {
         requireNonNull(filePath);
 
         Optional<JsonSerializableAddressBook> jsonAddressBook = JsonUtil.readJsonFile(
-                filePath, JsonSerializableAddressBook.class);
+            filePath, JsonSerializableAddressBook.class);
         if (!jsonAddressBook.isPresent()) {
             return Optional.empty();
         }
-
+        logger.info(String.valueOf(jsonAddressBook));
         try {
             return Optional.of(jsonAddressBook.get().toModelType());
         } catch (IllegalValueException ive) {

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -2,14 +2,17 @@ package seedu.address.storage;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
+import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.AddressBook;
+import seedu.address.model.ModelManager;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.group.Group;
 import seedu.address.model.student.Student;
@@ -24,6 +27,8 @@ class JsonSerializableAddressBook {
     public static final String MESSAGE_DUPLICATE_PERSON = "Students list contains duplicate student(s).";
     public static final String MESSAGE_DUPLICATE_GROUP = "Groups list contains duplicate group(s).";
     public static final String MESSAGE_DUPLICATE_TASK = "Tasks list contains duplicate task(s).";
+
+    private static final Logger logger = LogsCenter.getLogger(JsonSerializableAddressBook.class);
 
     private final List<JsonAdaptedPerson> persons = new ArrayList<>();
     private final List<JsonAdaptedGroup> groups = new ArrayList<>();
@@ -66,7 +71,9 @@ class JsonSerializableAddressBook {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_PERSON);
             }
             addressBook.addStudent(student);
+            logger.info("Added student " + student.getName() + " to address book");
         }
+
 
         for (JsonAdaptedGroup jsonAdaptedGroup : groups) {
             Group group = jsonAdaptedGroup.toModelType();
@@ -74,6 +81,7 @@ class JsonSerializableAddressBook {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_GROUP);
             }
             addressBook.addGroup(group);
+            logger.info("Added group " + group.getGroupName() + " to address book");
         }
 
         for (JsonAdaptedTask jsonAdaptedTask : tasks) {
@@ -82,6 +90,7 @@ class JsonSerializableAddressBook {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_TASK);
             }
             addressBook.addTask(task);
+            logger.info("Added task " + task.getTaskName() + " to address book");
         }
         return addressBook;
     }

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.AddressBook;
-import seedu.address.model.ModelManager;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.group.Group;
 import seedu.address.model.student.Student;


### PR DESCRIPTION
closes #193 

Updated the following classes to use `.equalsIgnoreCase()` in their equals method:

- `GroupName.java`
- `Email.java`
- `Student/Name.java`
- `TaskName.java`
- `Tag.java`

While some of these classes (Student Name allow duplicates), this ensures the comparing works correctly.


closes #192 
Updated Constraint message to include hyphen