### PR TITLE
Fix duplicate group bug

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -56,9 +56,6 @@ public class LogicManager implements Logic {
         } catch (DataLoadingException e) {
             tempVersionHistory = new VersionHistory();
         }
-        if (tempVersionHistory.getCurrentVersionIndex() == -1) {
-            tempVersionHistory.addVersion(model);
-        }
         this.versionHistory = tempVersionHistory;
         try {
             if (storage.readAddressBook().isEmpty()) {
@@ -75,10 +72,12 @@ public class LogicManager implements Logic {
     @Override
     public CommandResult execute(String commandText) throws CommandException, ParseException {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
-
         CommandResult commandResult;
         Command command = addressBookParser.parseCommand(commandText);
         commandResult = command.execute(model);
+        if (versionHistory.getCurrentVersionIndex() == -1) {
+            versionHistory.addVersion(model);
+        }
         this.versionHistory = command.updateVersionHistory(versionHistory, model);
         try {
             ReadOnlyAddressBook tempAddressBook =


### PR DESCRIPTION
Fixed the GUI bug, also added the functionality recognising when a user enters duplicate groups under the same command.
<img width="1440" alt="Screenshot 2024-11-06 at 2 33 11 AM" src="https://github.com/user-attachments/assets/93268bc0-518b-411d-b918-f61327c2b165">
<img width="1440" alt="Screenshot 2024-11-06 at 2 33 21 AM" src="https://github.com/user-attachments/assets/06b891f4-b4a2-4c5e-b23d-0142b8854072">

@ghos7ie for the example above I feel like since we can still allow users to add the group (means the command is fulfilled) I changed it from an exception to a sort of a warning message. So the command above won't raise an exception at all. However if a user enters a group name that is currently already in the model, only then will an exception be raised. Lmk if this is ok with y'all. Also lmk if there are any bugs from this pr cos I didn't really do an in-depth test yet but the previously raised problems should be fixed.